### PR TITLE
add: adding NURBS patch integration to additional integrators

### DIFF
--- a/fem/bilininteg.cpp
+++ b/fem/bilininteg.cpp
@@ -856,7 +856,6 @@ void DiffusionIntegrator::AssembleElementMatrix
       */
 
       MFEM_VERIFY(kv.Size() == dim, "Sanity check (remove later)");
-
       irn = &patchRule->GetElementRule(NURBSFE->GetElement(), patch, ijk, kv);
    }
 
@@ -2818,11 +2817,31 @@ void ElasticityIntegrator::AssembleElementMatrix(
       ir = &IntRules.Get(el.GetGeomType(), order);
    }
 
+   const NURBSFiniteElement *NURBSFE =
+	   dynamic_cast<const NURBSFiniteElement *>(&el);
+
+   IntegrationRule *irn = nullptr;
+   if (NURBSFE && patchRule)
+   {
+      const int patch = NURBSFE->GetPatch();
+      int ijk[3];
+      NURBSFE->GetIJK(ijk);
+      Array<const KnotVector*>& kv = NURBSFE->KnotVectors();
+
+      MFEM_VERIFY(kv.Size() == dim, "Sanity check (remove later)");
+
+      irn = &patchRule->GetElementRule(NURBSFE->GetElement(), patch, ijk, kv);
+   }
+
+   const int numIP = irn ? irn->GetNPoints() : ir->GetNPoints();
+
    elmat = 0.0;
 
-   for (int i = 0; i < ir -> GetNPoints(); i++)
+   // for (int i = 0; i < ir->GetNPoints(); i++)
+   for (int i = 0; i < numIP; i++)
    {
-      const IntegrationPoint &ip = ir->IntPoint(i);
+      // const IntegrationPoint &ip = ir->IntPoint(i);
+      const IntegrationPoint &ip = irn ? irn->IntPoint(i) : ir->IntPoint(i);
 
       el.CalcDShape(ip, dshape);
 

--- a/fem/lininteg.cpp
+++ b/fem/lininteg.cpp
@@ -36,6 +36,12 @@ void LinearFormIntegrator::AssembleRHSElementVect(
    mfem_error("LinearFormIntegrator::AssembleRHSElementVect(...)");
 }
 
+void LinearFormIntegrator::AssembleNURBSPatchVect(
+	const FiniteElement &el, ElementTransformation &Tr, Vector &elvect)
+{
+   mfem_error("LinearFormIntegrator::AssembleNURBSPatchVect(...)");
+}
+
 void DomainLFIntegrator::AssembleRHSElementVect(const FiniteElement &el,
                                                 ElementTransformation &Tr,
                                                 Vector &elvect)
@@ -286,9 +292,27 @@ void VectorDomainLFIntegrator::AssembleRHSElementVect(
       ir = &IntRules.Get(el.GetGeomType(), intorder);
    }
 
-   for (int i = 0; i < ir->GetNPoints(); i++)
+   const NURBSFiniteElement *NURBSFE =
+	   dynamic_cast<const NURBSFiniteElement *>(&el);
+
+   IntegrationRule *irn = nullptr;
+   if (NURBSFE && patchRule)
    {
-      const IntegrationPoint &ip = ir->IntPoint(i);
+      const int patch = NURBSFE->GetPatch();
+      int ijk[3];
+      NURBSFE->GetIJK(ijk);
+      Array<const KnotVector*>& kv = NURBSFE->KnotVectors();
+
+      irn = &patchRule->GetElementRule(NURBSFE->GetElement(), patch, ijk, kv);
+   }
+
+   const int numIP = irn ? irn->GetNPoints() : ir->GetNPoints();
+
+   // for (int i = 0; i < ir->GetNPoints(); i++)
+   for (int i = 0; i < numIP; i++)
+   {
+      // const IntegrationPoint &ip = ir->IntPoint(i);
+      const IntegrationPoint &ip = irn ? irn->IntPoint(i) : ir->IntPoint(i);
 
       Tr.SetIntPoint (&ip);
       val = Tr.Weight();

--- a/fem/lininteg.hpp
+++ b/fem/lininteg.hpp
@@ -25,6 +25,7 @@ class LinearFormIntegrator
 {
 protected:
    const IntegrationRule *IntRule;
+   NURBSPatchRule *patchRule = nullptr;
 
    LinearFormIntegrator(const IntegrationRule *ir = NULL) { IntRule = ir; }
 
@@ -50,9 +51,15 @@ public:
                                        const FiniteElement &el2,
                                        FaceElementTransformations &Tr,
                                        Vector &elvect);
+   virtual void AssembleNURBSPatchVect(const FiniteElement &el,
+				       ElementTransformation &Tr,
+				       Vector &elvect);
 
    virtual void SetIntRule(const IntegrationRule *ir) { IntRule = ir; }
    const IntegrationRule* GetIntRule() { return IntRule; }
+
+   void SetNURBSPatchIntRule(NURBSPatchRule *pr) { patchRule = pr; }
+   bool HasNURBSPatchRule() { return patchRule != nullptr; }
 
    virtual ~LinearFormIntegrator() { }
 };


### PR DESCRIPTION
This PR adds the NURBS patch integration to some addtional integrators and forms in MFEM (essentially copying code into multiple places).